### PR TITLE
#2 Set the interpreter to LaTex before setting the string.

### DIFF
--- a/src/@Plot/Dist2D.m
+++ b/src/@Plot/Dist2D.m
@@ -101,8 +101,8 @@ function Dist2D(o,varargin)
     ylabel('$p_\perp$','Interpreter','latex')                        
 
     hC = colorbar;
-    hC.Label.String = '$\log_{10}(F)$';
     hC.Label.Interpreter = 'Latex';
+    hC.Label.String = '$\log_{10}(F)$';
 
     title(sprintf('$\\tau = %.3g$ (relativistic coll. times)',...
                         oN.times(iteration)),'Interpreter','latex');
@@ -125,8 +125,8 @@ function Dist2D(o,varargin)
     ylabel('$p$','Interpreter','latex');
 
     hC = colorbar;
-    hC.Label.String = '$\log_{10}(F)$';
     hC.Label.Interpreter = 'Latex';
+    hC.Label.String = '$\log_{10}(F)$';
 
     title(sprintf('$\\tau = %.3g$ (relativistic coll. times)',...
                         oN.times(iteration)),'Interpreter','latex');

--- a/src/@Plot/DistMovie2D.m
+++ b/src/@Plot/DistMovie2D.m
@@ -78,8 +78,8 @@ function DistMovie2D(o,varargin)
         title(sprintf('$\\tau=%.3f$ (relativistic coll. times)',...
                                 oN.times(i)),'Interpreter','latex');
         hC = colorbar;
-        hC.Label.String = '$\log_{10}(F)$';
         hC.Label.Interpreter = 'Latex';
+        hC.Label.String = '$\log_{10}(F)$';
         axis equal
 
         %Make sure the colour scale is consistent

--- a/src/@Plot/DistVsTime.m
+++ b/src/@Plot/DistVsTime.m
@@ -86,6 +86,6 @@ function DistVsTime(o,varargin)
     ylabel('$\tau$','Interpreter','latex');
     colormap(o.ColorMap(numel(contours)));
     hC = colorbar;
-    hC.Label.String = '$\log_{10}(F)$';
     hC.Label.Interpreter = 'Latex';
+    hC.Label.String = '$\log_{10}(F)$';
 end


### PR DESCRIPTION
Was solved by setting the Label.Interpreter to LaTeX before setting the Label.String. All occurrences checked in the code. Warnings disappeared. 