### PR TITLE
Feature init distr

### DIFF
--- a/src/@Grid/InitializeGrid.m
+++ b/src/@Grid/InitializeGrid.m
@@ -36,7 +36,7 @@ function InitializeGrid(o)
                 p = s.^4+o.pGridParameter*s;
                 dpds = 4*s.^3+o.pGridParameter;
                 d2pds2 = 12*s.^2;                        
-            case 4 %A grid with a step in spacing, giving a dense 
+            case 4 %A grid with a tanh step in spacing, giving a dense 
                    %grid at low p and a sparse grid at high p                        
                 [p,dpds,d2pds2] = o.DefineStepMapping(s);                              
             otherwise

--- a/src/@NORSE/Initialize.m
+++ b/src/@NORSE/Initialize.m
@@ -185,7 +185,7 @@ function Initialize(o, varargin)
             %As an input, a structure must be given, with three fields
             %corresponding to f, extPBig, extXiBig.
             %Check if the external grid is the same as the created
-            if varargin{1}.extPBig == o.grid.pBig & varargin{1}.extXiBig == o.grid.xiBig
+            if varargin{1}.extPBig-o.grid.pBig<1e-12 & varargin{1}.extXiBig-o.grid.xiBig<1e-12
                 if nargin == 2
                     o.f(:,1) = varargin{1}.f;
                     o.Print('an externally given distribution.\n');

--- a/src/@NORSE/Initialize.m
+++ b/src/@NORSE/Initialize.m
@@ -187,8 +187,10 @@ function Initialize(o, varargin)
             
             % Check if the external grid is the same as the created
             % Create a logical variable
-            identicalGrid = max((varargin{1}.extPBig-o.grid.pBig)./varargin{1}.extPBig)<1e-12...
-                &&  max((varargin{1}.extXiBig-o.grid.xiBig)./varargin{1}.extXiBig)< 1e-12;
+            % Set a limit to the difference
+            limit = 1e-12;
+            identicalGrid = max((varargin{1}.extPBig-o.grid.pBig)./varargin{1}.extPBig)<limit...
+                &&  max((varargin{1}.extXiBig-o.grid.xiBig)./varargin{1}.extXiBig)< limit;
             
             if identicalGrid
                 if nargin == 2

--- a/src/@NORSE/Initialize.m
+++ b/src/@NORSE/Initialize.m
@@ -1,7 +1,8 @@
-function Initialize(o)
+function Initialize(o, varargin)
     % Initializes variables and sets up parameters and flags.
     % Usage: 
     %   Initialize()
+    %   Initialize(useExternalDistribution)
     %
     % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -173,6 +174,15 @@ function Initialize(o)
             o.f(:,1) = o.grid.MapGridToBigVector(...
                                     o.maxwellianPreFactor(0)*f0);
             o.Print('two shifted Maxwellians.\n');
+        case 4
+            %External distribution
+            if nargin == 2
+                o.f(:,1) = varargin{1};
+                o.Print('an externally given distribution.\n');
+            else
+                o.Print('incorrectly given.\n');
+                error('Invalid number of input arguments.');
+            end
         otherwise
             error('Invalid initial distribution');
     end        

--- a/src/@NORSE/Initialize.m
+++ b/src/@NORSE/Initialize.m
@@ -2,7 +2,13 @@ function Initialize(o, varargin)
     % Initializes variables and sets up parameters and flags.
     % Usage: 
     %   Initialize()
-    %   Initialize(useExternalDistribution)
+    %   Initialize(useExternalInput)
+    %
+    % For case 4 of the initialDistribution parameter an externally given
+    % distribution and two grid vectors must be provided in a
+    % structure form, with the the three inputs being three separate fields
+    % of the named structure. For more detail please check case 4 of the
+    % initialDistribution initialization.
     %
     % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -151,7 +157,7 @@ function Initialize(o, varargin)
             o.f(:,1) = o.MapLegModesToBigVector(initialF);
             o.Print('a weighted Maxwellian.\n');
         case 2  
-            %A shifted Mawellian   
+            %A shifted Maxwellian   
             pShift = o.maxwellianShift*sqrt(2*o.Theta(0));
             gamma0 = sqrt(1+pShift^2);
             gamma = sqrt(1+o.grid.p2D.^2);
@@ -161,7 +167,7 @@ function Initialize(o, varargin)
                                     o.maxwellianPreFactor(0)*f0);
             o.Print('a shifted Maxwellian.\n');
         case 3  
-            %Two shifted Mawellians                    
+            %Two shifted Maxwellians                    
             yShift = o.maxwellianShift;
 
             pShift1 = yShift*sqrt(2*o.Theta(0));
@@ -176,15 +182,22 @@ function Initialize(o, varargin)
             o.Print('two shifted Maxwellians.\n');
         case 4
             %External distribution
-            if nargin == 2
-                o.f(:,1) = varargin{1};
-                o.Print('an externally given distribution.\n');
+            %As an input, a structure must be given, with three fields
+            %corresponding to f, extPBig, extXiBig.
+            %Check if the external grid is the same as the created
+            if varargin{1}.extPBig == o.grid.pBig & varargin{1}.extXiBig == o.grid.xiBig
+                if nargin == 2
+                    o.f(:,1) = varargin{1}.f;
+                    o.Print('an externally given distribution.\n');
+                else
+                    error('Invalid number of input arguments.');
+                end
             else
-                o.Print('incorrectly given.\n');
-                error('Invalid number of input arguments.');
+                % To be written..
+                error('Interpolation required.');
             end
         otherwise
-            error('Invalid initial distribution');
+            error('Invalid initialDistribution parameter');
     end        
 
     %Calculate the potentials from f and save the the initial state

--- a/src/@NORSE/Initialize.m
+++ b/src/@NORSE/Initialize.m
@@ -181,16 +181,21 @@ function Initialize(o, varargin)
                                     o.maxwellianPreFactor(0)*f0);
             o.Print('two shifted Maxwellians.\n');
         case 4
-            %External distribution
-            %As an input, a structure must be given, with three fields
-            %corresponding to f, extPBig, extXiBig.
-            %Check if the external grid is the same as the created
-            if varargin{1}.extPBig-o.grid.pBig<1e-12 & varargin{1}.extXiBig-o.grid.xiBig<1e-12
+            % External distribution
+            % As an input, a structure must be given, with three fields
+            % corresponding to f, extPBig, extXiBig.
+            
+            % Check if the external grid is the same as the created
+            % Create a logical variable
+            identicalGrid = max((varargin{1}.extPBig-o.grid.pBig)./varargin{1}.extPBig)<1e-12...
+                &&  max((varargin{1}.extXiBig-o.grid.xiBig)./varargin{1}.extXiBig)< 1e-12;
+            
+            if identicalGrid
                 if nargin == 2
                     o.f(:,1) = varargin{1}.f;
                     o.Print('an externally given distribution.\n');
                 else
-                    error('Invalid number of input arguments.');
+                    error('Invalid number of input arguments for external distribution.');
                 end
             else
                 % To be written..

--- a/src/@NORSE/NORSE.m
+++ b/src/@NORSE/NORSE.m
@@ -453,7 +453,7 @@ classdef NORSE < matlab.mixin.Copyable
         Rewind(o,iSave)
             % Make an intermediate save step the final step, i.e. "rewind"
             % the calculation to a previous state. 
-        Initialize(o)
+        Initialize(o, varargin)
             % Initializes variables and sets up parameters and flags.            
         AdvanceInTime(o,varargin)
             % Interface method for the various underlying time-advance

--- a/src/@NORSE/PerformCalculation.m
+++ b/src/@NORSE/PerformCalculation.m
@@ -11,7 +11,7 @@ function PerformCalculation(o, varargin)
     %
     % The useExternalInput variable is a structure with fields
     % corresponding to the external distribution and external grid vectors.
-    % For more detail, please see Initialize.m.
+    % For more details, please see Initialize.m.
     %
     % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -33,14 +33,14 @@ function PerformCalculation(o, varargin)
         if nargin==3 && varargin{1}
             %Use an existing grid object, but make sure it is initialized
             o.grid.InitializeGrid();
-            o.Initialize(varargin{2});
         elseif nargin==2 
             %Create a new grid object
             o.grid = Grid(o);
-            o.Initialize(varargin{1});
         else
             error('Invalid number of input arguments.');
         end
+        % The last input argument is the external data
+        o.Initialize(varargin{end});
             
     else
        error('Invalid initial distribution.');

--- a/src/@NORSE/PerformCalculation.m
+++ b/src/@NORSE/PerformCalculation.m
@@ -1,6 +1,6 @@
 function PerformCalculation(o, varargin)
     %Carries out the various steps in a standard NORSE calculation. Optionally 
-    %uses and existing Grid object set in the NORSE class property grid -- 
+    %uses an existing Grid object set in the NORSE class property grid -- 
     %otherwise a new grid is generated using the settings in the NORSE object.
     %
     % Usage:
@@ -11,16 +11,75 @@ function PerformCalculation(o, varargin)
 
 
     tStart = tic;
-    if nargin==2 && varargin{1}
-        %Use an existing grid object, but make sure it is initialized
-        o.grid.InitializeGrid();
-    else
-        %Create a new grid object
-        o.grid = Grid(o);
+    %separate cases according to the need for external distribuiton
+    switch o.initialDistribution
+        case 0
+            if nargin==2 && varargin{1}
+                %Use an existing grid object, but make sure it is initialized
+                o.grid.InitializeGrid();
+            else
+                %Create a new grid object
+                o.grid = Grid(o);
+            end
+            o.Initialize();
+            o.timeAdvance.AdvanceInTime();                    
+            o.PostProcess();
+            o.timing.total = toc(tStart);
+            o.PrintTimings();
+        case 1
+            if nargin==2 && varargin{1}
+                %Use an existing grid object, but make sure it is initialized
+                o.grid.InitializeGrid();
+            else
+                %Create a new grid object
+                o.grid = Grid(o);
+            end
+            o.Initialize();
+            o.timeAdvance.AdvanceInTime();                    
+            o.PostProcess();
+            o.timing.total = toc(tStart);
+            o.PrintTimings();
+        case 2
+            if nargin==2 && varargin{1}
+                %Use an existing grid object, but make sure it is initialized
+                o.grid.InitializeGrid();
+            else
+                %Create a new grid object
+                o.grid = Grid(o);
+            end
+            o.Initialize();
+            o.timeAdvance.AdvanceInTime();                    
+            o.PostProcess();
+            o.timing.total = toc(tStart);
+            o.PrintTimings();
+        case 3
+            if nargin==2 && varargin{1}
+                %Use an existing grid object, but make sure it is initialized
+                o.grid.InitializeGrid();
+            else
+                %Create a new grid object
+                o.grid = Grid(o);
+            end
+            o.Initialize();
+            o.timeAdvance.AdvanceInTime();                    
+            o.PostProcess();
+            o.timing.total = toc(tStart);
+            o.PrintTimings();
+        case 4
+            if nargin==3 && varargin{1}
+                %Use an existing grid object, but make sure it is initialized
+                o.grid.InitializeGrid();
+                o.Initialize(varargin{2});
+            elseif nargin==2 
+                %Create a new grid object
+                o.grid = Grid(o);
+                o.Initialize(varargin{1});
+            end
+            o.timeAdvance.AdvanceInTime();                    
+            o.PostProcess();
+            o.timing.total = toc(tStart);
+            o.PrintTimings();
+        otherwise
+            error('Invalid initial distribution.');
     end
-    o.Initialize();
-    o.timeAdvance.AdvanceInTime();                    
-    o.PostProcess();
-    o.timing.total = toc(tStart);
-    o.PrintTimings();
 end

--- a/src/@NORSE/PerformCalculation.m
+++ b/src/@NORSE/PerformCalculation.m
@@ -6,80 +6,47 @@ function PerformCalculation(o, varargin)
     % Usage:
     %   PerformCalculation() 
     %   PerformCalculation(useExistingGrid)
+    %   PerformCalculation(useExternalInput)
+    %   PerformCalculation(useExistingGrid, useExternalInput)
+    %
+    % The useExternalInput variable is a structure with fields
+    % corresponding to the external distribution and external grid vectors.
+    % For more detail, please see Initialize.m.
     %
     % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
     tStart = tic;
-    %separate cases according to the need for external distribuiton
-    switch o.initialDistribution
-        case 0
-            if nargin==2 && varargin{1}
-                %Use an existing grid object, but make sure it is initialized
-                o.grid.InitializeGrid();
-            else
-                %Create a new grid object
-                o.grid = Grid(o);
-            end
-            o.Initialize();
-            o.timeAdvance.AdvanceInTime();                    
-            o.PostProcess();
-            o.timing.total = toc(tStart);
-            o.PrintTimings();
-        case 1
-            if nargin==2 && varargin{1}
-                %Use an existing grid object, but make sure it is initialized
-                o.grid.InitializeGrid();
-            else
-                %Create a new grid object
-                o.grid = Grid(o);
-            end
-            o.Initialize();
-            o.timeAdvance.AdvanceInTime();                    
-            o.PostProcess();
-            o.timing.total = toc(tStart);
-            o.PrintTimings();
-        case 2
-            if nargin==2 && varargin{1}
-                %Use an existing grid object, but make sure it is initialized
-                o.grid.InitializeGrid();
-            else
-                %Create a new grid object
-                o.grid = Grid(o);
-            end
-            o.Initialize();
-            o.timeAdvance.AdvanceInTime();                    
-            o.PostProcess();
-            o.timing.total = toc(tStart);
-            o.PrintTimings();
-        case 3
-            if nargin==2 && varargin{1}
-                %Use an existing grid object, but make sure it is initialized
-                o.grid.InitializeGrid();
-            else
-                %Create a new grid object
-                o.grid = Grid(o);
-            end
-            o.Initialize();
-            o.timeAdvance.AdvanceInTime();                    
-            o.PostProcess();
-            o.timing.total = toc(tStart);
-            o.PrintTimings();
-        case 4
-            if nargin==3 && varargin{1}
-                %Use an existing grid object, but make sure it is initialized
-                o.grid.InitializeGrid();
-                o.Initialize(varargin{2});
-            elseif nargin==2 
-                %Create a new grid object
-                o.grid = Grid(o);
-                o.Initialize(varargin{1});
-            end
-            o.timeAdvance.AdvanceInTime();                    
-            o.PostProcess();
-            o.timing.total = toc(tStart);
-            o.PrintTimings();
-        otherwise
-            error('Invalid initial distribution.');
+    %Separate cases according to the need for external distribuiton
+    if o.initialDistribution >= 0 && o.initialDistribution <=3
+        if nargin==2 && varargin{1}
+            %Use an existing grid object, but make sure it is initialized
+            o.grid.InitializeGrid();
+        else
+            %Create a new grid object
+            o.grid = Grid(o);
+        end
+        o.Initialize();
+    elseif o.initialDistribution == 4
+        % This case requires external distribution and grid vectors given
+        % to the Initialize method. See Initialize.m for more details.
+        if nargin==3 && varargin{1}
+            %Use an existing grid object, but make sure it is initialized
+            o.grid.InitializeGrid();
+            o.Initialize(varargin{2});
+        elseif nargin==2 
+            %Create a new grid object
+            o.grid = Grid(o);
+            o.Initialize(varargin{1});
+        else
+            error('Invalid number of input arguments.');
+        end
+            
+    else
+       error('Invalid initial distribution.');
     end
+    o.timeAdvance.AdvanceInTime();                    
+    o.PostProcess();
+    o.timing.total = toc(tStart);
+    o.PrintTimings();
 end

--- a/src/@TimeDependentParameter/TimeDependentParameter.m
+++ b/src/@TimeDependentParameter/TimeDependentParameter.m
@@ -72,7 +72,7 @@ classdef TimeDependentParameter
             %   par = TimeDependentParameter(t,f,isStepWiseConst,isConstOutsideRange); 
             
             if ~all(size(t) == size(f)) || ~isvector(t) || ~isnumeric(t) || ~isnumeric(f)
-                error('Invalid input argument dimenstions.');
+                error('Invalid input argument dimensions.');
             end
             if nargin >= 4  
                 if isscalar(varargin{1}) && isnumeric(varargin{1}) ...


### PR DESCRIPTION
NORSE can now be run with a numerical distribution as input. At this point this numerical distribution has to have a grid that is identical to the one produced by NORSE, so that it can be adapted without any interpolation.
This can be tested by running [externalNORSERun.m](https://github.com/hoppe93/NORSE/issues/4#issuecomment-448525974). This test file is not uploaded to the repository due to the sake of clarity. 
We have already reviewed the code amongst ourselves and tried to adapt the coding style. Please approve or advise on how to amend.

Later this feature can be generalized by allowing an input distribution with an arbitrary grid, but doing it safely will be a major effort due to the careful selection of the interpolation and extrapolation methods used.  I believe that this interpolation feature will deserve a new issue in the future, but it is not required for us, now.